### PR TITLE
Adding Sharpe Ration Gain Function

### DIFF
--- a/Main_Modelling_file.ipynb
+++ b/Main_Modelling_file.ipynb
@@ -109,7 +109,11 @@
     "                    break\n",
     "            if abs(ros - best_ros) < tol:\n",
     "                break\n",
-    "    return best_param"
+    "    return best_param\n",
+    "\n",
+    "def Sharpe_gain(Sharpe_val, Roo2_val):\n",
+    "    SR_star = np.sqrt(((Sharpe_val**2)+Roo2_val)/(1-Roo2_val))\n",
+    "    return SR_star - Sharpe_val"
    ]
   },
   {


### PR DESCRIPTION
Added a function to compute the Sharpe ration gain from the Roos of the model in order to reproduce the first line of table A.7 in the paper appendix.